### PR TITLE
Improve agenda and cost display

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -285,9 +285,9 @@ const Dashboard = () => {
 
       let rev = 0, cost = 0;
 
-      // Only calculate revenue if hours are verified (webhook_verified = true)
+      // Only calculate revenue and costs if hours are verified
       const isVerified = entry.manual_verified === true;
-      
+
       if (isVerified) {
         if (su > 0) {
           rev += su * rate.billable * 2;
@@ -305,12 +305,6 @@ const Dashboard = () => {
           rev += reg * rate.billable;
           cost += reg * rate.hourly;
         }
-      } else {
-        // Still calculate costs even if not verified
-        if (su > 0) cost += su * rate.sunday;
-        if (wk > 0) cost += wk * rate.saturday;
-        if (ot > 0) cost += ot * rate.hourly * 1.25;
-        if (reg > 0) cost += reg * rate.hourly;
       }
 
       if (isVerified && billedHours > actualHours) {
@@ -324,7 +318,7 @@ const Dashboard = () => {
       if (isVerified && travel.fromClient > 0) {
         rev += travel.fromClient;
       }
-      if (travel.toTech > 0) {
+      if (isVerified && travel.toTech > 0) {
         cost += travel.toTech;
       }
 

--- a/src/components/WorkSchedule.tsx
+++ b/src/components/WorkSchedule.tsx
@@ -313,13 +313,12 @@ const WorkSchedulePage: React.FC = () => {
               month={displayedMonth}
               onMonthChange={setDisplayedMonth}
               selected={selectedTech === 'all' ? undefined : workDays}
-              onSelect={dates => {
+              onDayClick={(date, modifiers) => {
+                // Ensure single click selects even for outside days
                 if (selectedTech === 'all') return;
-                setWorkDays(dates as Date[]);
-              }}
-              onDayClick={(date) => {
-                // Mobile single-click to toggle work day
-                if (selectedTech === 'all') return;
+                if (modifiers.outside) {
+                  setDisplayedMonth(date);
+                }
                 const dateStr = date.toDateString();
                 const isSelected = workDays.some(d => d.toDateString() === dateStr);
                 if (isSelected) {


### PR DESCRIPTION
## Summary
- allow selecting outside days with a single click in Agenda
- show costs on the dashboard only when the hours are verified

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6875bd1b7b5c833090f1912166c544c3