### PR TITLE
Implement dashboard improvements

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -75,7 +75,7 @@ const Dashboard = () => {
 
   useEffect(() => {
     if (!rawWorkHours.length) return;
-    let filtered = rawWorkHours;
+    let filtered = rawWorkHours.filter(e => e.manual_verified === true);
 
     if (isAdmin) {
       if (selectedTechnician !== 'all') {
@@ -107,7 +107,12 @@ const Dashboard = () => {
     }
     setTechnicianData(processTechnicianData(filtered, rawRates, travelRates));
     setWeeklyData(processWeeklyData(filtered, isAdmin ? null : user?.id));
-    if (isAdmin) setWeeklyAdminData(processWeeklyData(rawWorkHours));
+    if (isAdmin)
+      setWeeklyAdminData(
+        processWeeklyData(
+          rawWorkHours.filter(e => e.manual_verified === true)
+        )
+      );
   }, [rawWorkHours, rawRates, travelRates, selectedTechnician, selectedMonth, isAdmin, user?.id]);
 
   const fetchDashboardData = async () => {
@@ -268,6 +273,8 @@ const Dashboard = () => {
           profit: 0,
           revenue: 0,
           costs: 0,
+          travelCost: 0,
+          travelRevenue: 0,
         });
       }
       const s = techMap.get(id);
@@ -317,9 +324,11 @@ const Dashboard = () => {
 
       if (isVerified && travel.fromClient > 0) {
         rev += travel.fromClient;
+        s.travelRevenue += travel.fromClient;
       }
       if (isVerified && travel.toTech > 0) {
         cost += travel.toTech;
+        s.travelCost += travel.toTech;
       }
 
       const profit = rev - cost;
@@ -636,6 +645,10 @@ const Dashboard = () => {
                             <div className="font-semibold text-gray-800"><ZakelijkEuro value={t.costs} /></div>
                           </div>
                           <div>
+                            <div className="text-xs text-gray-400 mb-1">Reiskosten</div>
+                            <div className="font-semibold text-gray-800"><ZakelijkEuro value={t.travelCost} /></div>
+                          </div>
+                          <div>
                             <div className="text-xs text-gray-400 mb-1">Winst</div>
                             <div className={`font-bold ${t.profit >= 0 ? 'text-green-700' : 'text-red-700'}`}>
                               <ZakelijkEuro value={t.profit} />
@@ -682,6 +695,10 @@ const Dashboard = () => {
                         <div className="flex flex-col items-start">
                           <span className="text-xs text-gray-400">Kosten</span>
                           <span className="font-semibold text-gray-800"><ZakelijkEuro value={t.costs} /></span>
+                        </div>
+                        <div className="flex flex-col items-start">
+                          <span className="text-xs text-gray-400">Reiskosten</span>
+                          <span className="font-semibold text-gray-800"><ZakelijkEuro value={t.travelCost} /></span>
                         </div>
                         <div className="flex flex-col items-start">
                           <span className="text-xs text-gray-400">Winst</span>

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -11,12 +11,46 @@ function Calendar({
   className,
   classNames,
   showOutsideDays = true,
+  onDayClick,
   ...props
 }: CalendarProps) {
+  const handleDayClick = React.useCallback(
+    (day: Date, modifiers: any, e: React.MouseEvent) => {
+      if (modifiers.outside && props.onMonthChange) {
+        props.onMonthChange(day);
+      }
+      if (modifiers.outside && props.onSelect) {
+        if (props.mode === "single") {
+          props.onSelect(day as any, day, modifiers, e);
+        } else if (props.mode === "multiple") {
+          const current = Array.isArray(props.selected) ? props.selected : [];
+          const exists = current.some(d => d && d.toDateString() === day.toDateString());
+          const next = exists
+            ? current.filter(d => d && d.toDateString() !== day.toDateString())
+            : [...current, day];
+          props.onSelect(next as any, day, modifiers, e);
+        } else if (props.mode === "range") {
+          const range = props.selected as any;
+          if (!range || (range.from && range.to)) {
+            props.onSelect({ from: day, to: undefined } as any, day, modifiers, e);
+          } else if (range.from && !range.to) {
+            if (day < range.from) {
+              props.onSelect({ from: day, to: range.from } as any, day, modifiers, e);
+            } else {
+              props.onSelect({ from: range.from, to: day } as any, day, modifiers, e);
+            }
+          }
+        }
+      }
+      onDayClick?.(day, modifiers, e);
+    },
+    [onDayClick, props]
+  );
   return (
     <DayPicker
       showOutsideDays={showOutsideDays}
       className={cn("p-3", className)}
+      onDayClick={handleDayClick}
       classNames={{
         months: "flex flex-col sm:flex-row space-y-4 sm:space-x-4 sm:space-y-0",
         month: "space-y-4",

--- a/src/types/workHours.ts
+++ b/src/types/workHours.ts
@@ -36,6 +36,8 @@ export interface TechnicianSummary {
   profit: number;
   revenue: number;
   costs: number;
+  travelCost: number;
+  travelRevenue: number;
 }
 
 export interface OvertimeCalculation {


### PR DESCRIPTION
## Summary
- tweak calendar day picker to select outside days with single click
- ignore unverified hours in dashboard calculations
- track travel costs per technician
- show travel costs in performance overview

## Testing
- `npm install` *(fails: unable to download packages)*

------
https://chatgpt.com/codex/tasks/task_e_6875c5583adc833095467ac7b0416605