### PR TITLE
Add daily project email and simplify opdrachtgever view

### DIFF
--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -270,6 +270,7 @@ const Projects = () => {
 
   useEffect(() => {
     if (
+      !isOpdrachtgever &&
       customers.length === 1 &&
       (!newProject.customerId || !customers.some(c => c.id === newProject.customerId)) &&
       showAddForm
@@ -280,6 +281,8 @@ const Projects = () => {
   }, [customers, showAddForm]);
 
   const isAdmin = user?.role === 'admin' || user?.role === 'opdrachtgever';
+  const isSiteAdmin = user?.role === 'admin';
+  const isOpdrachtgever = user?.role === 'opdrachtgever';
 
   const technicians = Array.from(
     new Map(projects.map(p => [p.technicianId, p.technicianName])).entries()
@@ -336,7 +339,7 @@ const Projects = () => {
     if (
       !newProject.title ||
       !newProject.date ||
-      !newProject.customerId ||
+      (!isOpdrachtgever && !newProject.customerId) ||
       (isAdmin && !newProject.technicianId) ||
       (newProject.status === 'completed' && !newProject.hoursSpent)
     ) {
@@ -366,7 +369,7 @@ const Projects = () => {
           date: newProject.date,
           hours_spent: newProject.hoursSpent !== '' ? parseFloat(newProject.hoursSpent) : 0,
           status: newProject.status,
-          customer_id: newProject.customerId,
+          customer_id: newProject.customerId || null,
           technician_id: technicianIdToSave,
           is_public: newProject.isPublic
         })
@@ -380,7 +383,7 @@ const Projects = () => {
     } else {
       const { data, error } = await supabase.from('projects').insert([{
         technician_id: technicianIdToSave,
-        customer_id: newProject.customerId,
+        customer_id: newProject.customerId || null,
         title: newProject.title,
         description: newProject.description,
         date: newProject.date,
@@ -501,6 +504,30 @@ const Projects = () => {
     setDetailsOpen(true);
   };
 
+  const handleSendDailyReport = async () => {
+    const today = new Date().toISOString().split('T')[0];
+    const todaysProjects = projects.filter(p => p.date === today);
+    if (todaysProjects.length === 0) {
+      toast({ title: 'Geen projecten', description: 'Er zijn vandaag geen projecten.' });
+      return;
+    }
+    const withUrls = await Promise.all(todaysProjects.map(async p => {
+      const urls = await getSignedUrls(p.images);
+      return { ...p, urls };
+    }));
+    let body = `Projecten van ${today}\n\n`;
+    withUrls.forEach(p => {
+      body += `${p.title} - ${p.technicianName} (${p.hoursSpent}u)\n`;
+      if (p.description) body += `${p.description}\n`;
+      if (p.urls.length) {
+        p.urls.forEach(u => { body += `${u}\n`; });
+      }
+      body += '\n';
+    });
+    const mailto = `mailto:?subject=Projecten%20${today}&body=${encodeURIComponent(body)}`;
+    window.location.href = mailto;
+  };
+
   // PROJECTCARD inclusief tooltip op hover én statusknoppen
   const renderProjectCard = (project: Project) => (
     <Tooltip key={project.id}>
@@ -613,29 +640,36 @@ const Projects = () => {
             <h1 className="mb-2 text-3xl font-bold text-gray-900">{isAdmin ? 'Alle Projecten' : 'Mijn Projecten'}</h1>
             <p className="text-gray-600">{isAdmin ? 'Bekijk alle monteur projecten' : 'Volg je dagelijkse projecten en werk'}</p>
           </div>
-          <Button
-            onClick={() => {
-              setShowAddForm(!showAddForm);
-              setEditingProject(null);
-              setNewProject({
-                title: '',
-                description: '',
-                hoursSpent: '',
-                customerId: '',
-                date: new Date().toISOString().split('T')[0],
-                status: 'in-progress',
-                technicianId: '',
-                isPublic: false
-              });
-            }}
-            className="bg-red-600 text-white hover:bg-red-700"
-          >
-            <Plus className="mr-2 h-4 w-4" />
-            {showAddForm ? 'Annuleren' : 'Project Toevoegen'}
-          </Button>
+          <div className="flex space-x-2">
+            <Button
+              onClick={() => {
+                setShowAddForm(!showAddForm);
+                setEditingProject(null);
+                setNewProject({
+                  title: '',
+                  description: '',
+                  hoursSpent: '',
+                  customerId: '',
+                  date: new Date().toISOString().split('T')[0],
+                  status: 'in-progress',
+                  technicianId: '',
+                  isPublic: false
+                });
+              }}
+              className="bg-red-600 text-white hover:bg-red-700"
+            >
+              <Plus className="mr-2 h-4 w-4" />
+              {showAddForm ? 'Annuleren' : 'Project Toevoegen'}
+            </Button>
+            {isAdmin && (
+              <Button onClick={handleSendDailyReport} className="bg-blue-600 text-white hover:bg-blue-700">
+                Dagrapport
+              </Button>
+            )}
+          </div>
         </div>
 
-        {isAdmin && (
+        {isSiteAdmin && (
           <div className="mb-6 flex items-center space-x-4">
             <select
               value={selectedTech}
@@ -675,21 +709,23 @@ const Projects = () => {
                     onChange={e => setNewProject({ ...newProject, title: e.target.value })}
                   />
                 </div>
-                <div>
-                  <Label htmlFor="customer">Klant *</Label>
-                  <select
-                    id="customer"
-                    required
-                    value={newProject.customerId}
-                    onChange={e => setNewProject({ ...newProject, customerId: e.target.value })}
-                    className="w-full rounded border p-2"
-                  >
-                    <option value="">Selecteer Klant</option>
-                    {customers.map(c => (
-                      <option key={c.id} value={c.id}>{c.name}</option>
-                    ))}
-                  </select>
-                </div>
+                {!isOpdrachtgever && (
+                  <div>
+                    <Label htmlFor="customer">Klant *</Label>
+                    <select
+                      id="customer"
+                      required
+                      value={newProject.customerId}
+                      onChange={e => setNewProject({ ...newProject, customerId: e.target.value })}
+                      className="w-full rounded border p-2"
+                    >
+                      <option value="">Selecteer Klant</option>
+                      {customers.map(c => (
+                        <option key={c.id} value={c.id}>{c.name}</option>
+                      ))}
+                    </select>
+                  </div>
+                )}
                 {isAdmin && (
                   <div>
                     <Label htmlFor="technician">Monteur *</Label>

--- a/src/utils/sendDailyProjectReport.ts
+++ b/src/utils/sendDailyProjectReport.ts
@@ -1,0 +1,14 @@
+import { supabase } from '@/integrations/supabase/client';
+
+export const sendDailyProjectReport = async (date: string, email: string) => {
+  try {
+    const { data, error } = await supabase.functions.invoke('project-report-email', {
+      body: { date, email }
+    });
+    if (error) throw error;
+    return data as { ok: boolean; count: number };
+  } catch (err) {
+    console.error('sendDailyProjectReport error', err);
+    throw err;
+  }
+};

--- a/supabase/functions/project-report-email/deno.json
+++ b/supabase/functions/project-report-email/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "@supabase/supabase-js": "https://esm.sh/@supabase/supabase-js@2.50.0"
+  }
+}

--- a/supabase/functions/project-report-email/index.ts
+++ b/supabase/functions/project-report-email/index.ts
@@ -1,0 +1,47 @@
+/// <reference lib="deno.ns" />
+import "https://deno.land/x/xhr@0.1.0/mod.ts";
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.50.0';
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  try {
+    const { date, email } = await req.json();
+    console.log('Project report email', { date, email });
+    const supabaseUrl = Deno.env.get('SUPABASE_URL')!;
+    const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+    const supabase = createClient(supabaseUrl, supabaseServiceKey);
+
+    const { data: projects, error } = await supabase
+      .from('projects')
+      .select('title, description, hours_spent, images, profiles(full_name)')
+      .eq('date', date);
+    if (error) throw error;
+
+    // Here you could integrate with an email service
+    await supabase.from('project_report_logs').insert({
+      date,
+      email,
+      project_count: projects?.length || 0,
+    });
+
+    return new Response(
+      JSON.stringify({ ok: true, count: projects?.length || 0 }),
+      { headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+    );
+  } catch (error) {
+    console.error('Project report email error', error);
+    return new Response(
+      JSON.stringify({ error: 'failed' }),
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- add `project-report-email` edge function
- add helper `sendDailyProjectReport`
- allow sending a day report mail from project list
- hide customer dropdown for opdrachtgever and hide technician filter
- show project metrics on opdrachtgever dashboard instead of hour totals

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875cb2e7614833096a50e7845758e11