### PR TITLE
Add admin chat history view

### DIFF
--- a/src/components/ChatHistory.tsx
+++ b/src/components/ChatHistory.tsx
@@ -1,0 +1,133 @@
+import React, { useState, useEffect } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Table, TableHead, TableBody, TableRow, TableCell, TableHeader } from '@/components/ui/table';
+import { Input } from '@/components/ui/input';
+import TechnicianFilter from './TechnicianFilter';
+import { useAuth } from '@/contexts/AuthContext';
+import { supabase } from '@/integrations/supabase/client';
+import { ChatHistory } from '@/types/chatHistory';
+
+interface Technician { id: string; full_name: string; }
+
+const ChatHistoryPage: React.FC = () => {
+  const { user } = useAuth();
+  const [messages, setMessages] = useState<ChatHistory[]>([]);
+  const [technicians, setTechnicians] = useState<Technician[]>([]);
+  const [selectedTech, setSelectedTech] = useState<string>('all');
+  const [selectedDate, setSelectedDate] = useState<string>('');
+  const [loading, setLoading] = useState(true);
+
+  const fetchTechnicians = async () => {
+    const { data, error } = await supabase
+      .from('profiles')
+      .select('id, full_name')
+      .eq('role', 'technician')
+      .order('full_name');
+    if (!error && data) setTechnicians(data);
+  };
+
+  const fetchMessages = async () => {
+    setLoading(true);
+    let query = supabase
+      .from('n8n_chat_histories')
+      .select('*')
+      .order('created_at', { ascending: false });
+
+    if (selectedTech !== 'all') {
+      query = query.eq('session_id', selectedTech);
+    }
+    if (selectedDate) {
+      const start = new Date(selectedDate);
+      start.setHours(0, 0, 0, 0);
+      const end = new Date(selectedDate);
+      end.setHours(23, 59, 59, 999);
+      query = query.gte('created_at', start.toISOString()).lte('created_at', end.toISOString());
+    }
+
+    const { data, error } = await query;
+    if (!error && data) setMessages(data as ChatHistory[]);
+    setLoading(false);
+  };
+
+  useEffect(() => {
+    fetchTechnicians();
+  }, []);
+
+  useEffect(() => {
+    fetchMessages();
+  }, [selectedTech, selectedDate]);
+
+  if (user?.role !== 'admin') {
+    return (
+      <div className="p-6 bg-gray-50 min-h-screen">
+        <div className="text-center">
+          <h1 className="text-2xl font-bold text-red-600">Geen toegang</h1>
+          <p className="text-gray-600 mt-2">Alleen admins hebben toegang tot deze pagina.</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-6 bg-gray-50 min-h-screen">
+      <div className="max-w-7xl mx-auto">
+        <div className="mb-8">
+          <h1 className="text-3xl font-bold text-gray-900 mb-2">Chatgeschiedenis</h1>
+          <p className="text-gray-600">Overzicht van verzonden berichten naar de AI chatbot</p>
+        </div>
+
+        <div className="flex flex-col md:flex-row gap-4 mb-4">
+          <TechnicianFilter
+            technicians={technicians.map(t => ({ id: t.id, name: t.full_name }))}
+            selectedTechnician={selectedTech}
+            onTechnicianChange={setSelectedTech}
+          />
+          <div>
+            <label htmlFor="historyDate" className="block text-sm font-medium text-gray-700 mb-1">Datum</label>
+            <Input
+              id="historyDate"
+              type="date"
+              value={selectedDate}
+              onChange={e => setSelectedDate(e.target.value)}
+              className="w-40"
+            />
+          </div>
+        </div>
+
+        {loading ? (
+          <div className="flex items-center justify-center h-32">
+            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-red-600"></div>
+          </div>
+        ) : (
+          <Card className="bg-white shadow-sm">
+            <CardHeader>
+              <CardTitle className="text-lg font-semibold text-gray-900">Berichten</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Datum</TableHead>
+                    <TableHead>Monteur</TableHead>
+                    <TableHead>Bericht</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {messages.map(msg => (
+                    <TableRow key={msg.id}>
+                      <TableCell>{new Date(msg.created_at).toLocaleString('nl-NL')}</TableCell>
+                      <TableCell>{technicians.find(t => t.id === msg.session_id)?.full_name || msg.session_id}</TableCell>
+                      <TableCell className="whitespace-pre-wrap">{msg.message}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </CardContent>
+          </Card>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default ChatHistoryPage;

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -42,6 +42,7 @@ const Navigation: React.FC<NavigationProps> = ({ activeTab, onTabChange }) => {
     { id: 'verification', label: 'Uren Verificatie', icon: CheckCircle },
     { id: 'users', label: 'Gebruikersbeheer', icon: Users },
     { id: 'reports', label: 'Rapporten', icon: FileText },
+    { id: 'chat_history', label: 'Chatgeschiedenis', icon: FileText },
     { id: 'analytics', label: 'Analytics', icon: BarChart3 },
     { id: 'chatbot', label: 'AI Assistent', icon: Bot }
   ];

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -14,6 +14,7 @@ import AIChatbot from '@/components/AIChatbot';
 import WorkSchedulePage from '@/components/WorkSchedule';
 import Magazine from '@/components/Magazine';
 import Analytics from '@/components/Analytics';
+import ChatHistoryPage from '@/components/ChatHistory';
 
 const AppContent: React.FC = () => {
   const { isAuthenticated, loading, user } = useAuth();
@@ -24,7 +25,7 @@ const AppContent: React.FC = () => {
     if (savedTab && user) {
       // Validate saved tab is allowed for current user role
       const allowedTabs = user.role === 'admin' 
-        ? ['dashboard', 'hours', 'projects', 'magazine', 'schedule', 'customers', 'billing', 'verification', 'users', 'reports', 'chatbot', 'analytics']
+        ? ['dashboard', 'hours', 'projects', 'magazine', 'schedule', 'customers', 'billing', 'verification', 'users', 'reports', 'chatbot', 'chat_history', 'analytics']
         : user.role === 'opdrachtgever'
         ? ['dashboard', 'projects', 'schedule', 'chatbot']
         : ['dashboard', 'hours', 'projects', 'magazine', 'schedule', 'chatbot'];
@@ -114,6 +115,8 @@ const AppContent: React.FC = () => {
         return <Magazine />;
       case 'chatbot':
         return <AIChatbot />;
+      case 'chat_history':
+        return <ChatHistoryPage />;
       case 'analytics':
         return <Analytics />;
       default:

--- a/src/types/chatHistory.ts
+++ b/src/types/chatHistory.ts
@@ -1,0 +1,6 @@
+export interface ChatHistory {
+  id: string;
+  session_id: string;
+  message: string;
+  created_at: string;
+}


### PR DESCRIPTION
## Summary
- add ChatHistoryPage component
- register `chat_history` tab in navigation and tab switcher
- allow admins to view AI chat messages stored in Supabase
- add ChatHistory type

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_688157485a748330aeb7cc84e8c70aba