### PR TITLE
Fix technician listings

### DIFF
--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -232,6 +232,7 @@ const Projects = () => {
       const { data: profilesData } = await supabase
         .from('profiles')
         .select('id, full_name, customer')
+        .eq('role', 'technician')
         .order('full_name', { ascending: true });
       const { data: projectData } = await supabase
         .from('projects')

--- a/src/components/WorkSchedule.tsx
+++ b/src/components/WorkSchedule.tsx
@@ -71,7 +71,10 @@ const WorkSchedulePage: React.FC = () => {
 
   // Fetch technicians & assign colors
   async function fetchTechnicians() {
-    const { data } = await supabase.from('profiles').select('id, full_name');
+    const { data } = await supabase
+      .from('profiles')
+      .select('id, full_name')
+      .eq('role', 'technician');
     const list = data || [];
 
     // 1) Raw: alle technici uit de DB, of alleen de ingelogde tech als geen planner


### PR DESCRIPTION
## Summary
- restrict technician queries to role 'technician' when building the agenda and project dropdowns

## Testing
- `npm run lint` *(fails: eslint not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889eb30f4d08330a827af95672ce3aa